### PR TITLE
feat: all/any expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Now, write labeling rules to the YAML file pointed by `configuration-path`.
 # add fox label when "fox" is found
 fox:
   pattern: fox
-# add cat label when "cat" is found
+# add cat label when "cat" is found. Array is also accepted as an "all" expression.
 cat:
-  pattern: cat
+  - cat
 # add cow label when "cow" is found.
 # remove cow label if "cow" is missing.
 cow:
@@ -44,4 +44,28 @@ cow:
 # add regex label when the specified regular expression pattern is matching.
 regex:
   pattern: "[Tt]he.*\\."
+```
+
+For more complecated use cases, we can utilize complex expressions like:
+
+```yaml
+bat:
+  # Matches against phrase like "bat is animal and has wings".
+  # but "birds has wings." won't match.
+  all:
+    - wings?
+    - animal
+  # "all" can be reducted in this case; because an naked array will be treated as child node of "all":
+bat2:
+  - wings?
+  - animal
+```
+
+```yaml
+pirate:
+  # To detect pirates in issue, check any appearences of `Ahoy`, `matey`, `Rrrr!` and so on.
+  any:
+    - [Aa]hoy
+    - [Mm]atey
+    - ([AR]a*|Ya+)rrr+!
 ```

--- a/__tests__/expression.test.ts
+++ b/__tests__/expression.test.ts
@@ -1,0 +1,18 @@
+import { isMatch, Expression } from '../src/expression'
+
+describe('isMatch', () => {
+  const testCases: Array<[{ body: string }, Expression, boolean]> = [
+    [{ body: 'alice' }, 'a', true],
+    [{ body: 'alice' }, { pattern: 'a' }, true],
+    [{ body: 'bob' }, 'a', false],
+    [{ body: 'bob' }, { pattern: 'a' }, false],
+    [{ body: 'alice' }, ['a', 'l', 'i', 'c', 'e'], true],
+    [{ body: 'alice' }, ['a', 'l', 'i', 'k', 'e'], false],
+    [{ body: 'alice' }, { any: ['a', 'b'] }, true],
+    [{ body: '' }, {}, false]
+  ]
+
+  it.each(testCases)('for given document %j and expression %j, returns %p', async (doc, exp, outcome) => {
+    expect(isMatch({ body: doc.body }, exp)).toBe(outcome)
+  })
+})

--- a/__tests__/fixtures/example.yml
+++ b/__tests__/fixtures/example.yml
@@ -1,6 +1,6 @@
 # add fox label when "fox" is found
 fox:
-  pattern: fox
+  - fox
 # add cat label when "cat" is found
 cat:
   pattern: cat

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,0 +1,82 @@
+interface AnyExpression<T> {
+  any: T[]
+}
+
+interface AllExpression<T> {
+  all: T[]
+}
+
+// provides compatiblity
+interface PatternExpression {
+  pattern: string
+}
+
+export type Expression = AnyExpression<Expression> |
+  AllExpression<Expression> |
+  PatternExpression |
+  string |
+  Expression[] | { [key: string]: unknown };
+
+export interface Document {
+  body: string
+}
+
+function hasOwnProperty (o: any, key: string) {
+  return Object.prototype.hasOwnProperty.call(o, key)
+}
+
+function cast<TExpression> (e: Expression, key: keyof TExpression): TExpression | undefined {
+  if (hasOwnProperty(e, key as unknown as string)) {
+    return e as unknown as TExpression
+  }
+}
+
+function isMatchAllExpression (d: Document, exps: Expression[] | AllExpression<Expression>): boolean {
+  if (Array.isArray(exps)) {
+    for (const e of exps) {
+      if (!isMatch(d, e)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  for (const e of exps.all) {
+    if (!isMatch(d, e)) {
+      return false
+    }
+  }
+  return true
+}
+
+function isMatchAnyExpression (d: Document, exp: AnyExpression<Expression>): boolean {
+  for (const e of exp.any) {
+    if (isMatch(d, e)) {
+      return true
+    }
+  }
+  return false
+}
+
+export function isMatch (d: Document, e: Expression): boolean {
+  if (typeof e === 'string') {
+    return new RegExp(e).test(d.body)
+  }
+  if (Array.isArray(e)) {
+    return isMatchAllExpression(d, e)
+  }
+  const patternExp = cast<PatternExpression>(e, 'pattern')
+  if (patternExp) {
+    return new RegExp(patternExp.pattern).test(d.body)
+  }
+  const anyExp = cast<AnyExpression<Expression>>(e, 'any')
+  if (anyExp) {
+    return isMatchAnyExpression(d, anyExp)
+  }
+  const allExp = cast<AllExpression<Expression>>(e, 'all')
+  if (allExp) {
+    return isMatchAllExpression(d, allExp)
+  }
+  return false
+}


### PR DESCRIPTION
Allow using `all` or `any` to write complex matching like below:

```yaml
bat:
  # Matches against phrase like "bat is animal and has wings".
  # but "birds has wings." won't match.
  all:
    - wings?
    - animal
  # "all" can be reducted in this case; because an naked array will be treated as child node of "all":
bat2:
  - wings?
  - animal
```

```yaml
pirate:
  # To detect pirates in issue, check any appearences of `Ahoy`, `matey`, `Rrrr!` and so on.
  any:
    - [Aa]hoy
    - [Mm]atey
    - ([AR]a*|Ya+)rrr+!
```