### PR TITLE
build: remove unnecessary assets from release

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -5,7 +5,4 @@ plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/github"
-    - assets:
-      - dist/**
-      - action.yaml
   - "@semantic-release/changelog"


### PR DESCRIPTION
There's no use of assets attached to releases since this is gha.