### PR TITLE
chore: disable eslint plugin:promise/recommended

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,6 @@ export default [
     ...compat.config({
       extends: [
         'standard',
-        'plugin:promise/recommended',
         'plugin:jest/recommended'
       ]
     }),


### PR DESCRIPTION
Follows up https://github.com/oakcask/github-action-auto-label-issue/pull/441

`plugin:promise/recommended` is wrongly enabled by https://github.com/oakcask/github-action-auto-label-issue/pull/441