### PR TITLE
feat: process pull requests as same as issues

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -5,31 +5,26 @@ describe('parseContext', () => {
   beforeEach(() => {
     process.env.GITHUB_REPOSITORY = 'foo/bar'
     process.env.GITHUB_EVENT_PATH = '__tests__/fixtures/payload.json'
-    process.env.GITHUB_REF = 'refname'
   })
 
   it('takes owner/repo from env', () => {
     const ctx = parseContext()
-    expect(ctx?.repo.owner).toEqual('foo')
-    expect(ctx?.repo.repo).toEqual('bar')
+    expect(ctx?.owner).toEqual('foo')
+    expect(ctx?.repo).toEqual('bar')
   })
 
   it('takes owner/repo from payload instead if the env is empty', () => {
     delete process.env.GITHUB_REPOSITORY
     const ctx = parseContext()
-    expect(ctx?.repo.owner).toEqual('owner-in-payload')
-    expect(ctx?.repo.repo).toEqual('repo-in-payload')
+    expect(ctx?.owner).toEqual('owner-in-payload')
+    expect(ctx?.repo).toEqual('repo-in-payload')
   })
 
   it('takes issue number and body from payload', () => {
-    const ctx = parseContext()
-    expect(ctx?.issue.number).toEqual(42)
-    expect(ctx?.issue.body).toEqual('issue body')
-  })
-
-  it('takes ref from payload', () => {
-    const ctx = parseContext()
-    expect(ctx?.ref).toEqual('refname')
+    const ctx = parseContext()!
+    expect('issue' in ctx && ctx.issue.id).toEqual('issueid')
+    expect('issue' in ctx && ctx.issue.number).toEqual(42)
+    expect('issue' in ctx && ctx.issue.body).toEqual('issue body')
   })
 
   describe('when the payload withoout a issue', () => {
@@ -40,6 +35,19 @@ describe('parseContext', () => {
     it('is undefined', () => {
       const ctx = parseContext()
       expect(ctx).toBeUndefined()
+    })
+  })
+
+  describe('when the payload includes pull_request', () => {
+    beforeEach(() => {
+      process.env.GITHUB_EVENT_PATH = '__tests__/fixtures/payload.pull_request.json'
+    })
+
+    it('takes pull request number and body from payload', () => {
+      const ctx = parseContext()!
+      expect('pullRequest' in ctx && ctx.pullRequest.id).toEqual('prid')
+      expect('pullRequest' in ctx && ctx.pullRequest.number).toEqual(4242)
+      expect('pullRequest' in ctx && ctx.pullRequest.body).toEqual('pr body')
     })
   })
 })

--- a/__tests__/fixtures/payload.pull_request.json
+++ b/__tests__/fixtures/payload.pull_request.json
@@ -5,9 +5,9 @@
         },
         "name": "repo-in-payload"
     },
-    "issue": {
-        "node_id": "issueid",
-        "number": 42,
-        "body": "issue body"
+    "pull_request": {
+        "node_id": "prid",
+        "number": 4242,
+        "body": "pr body"
     }
 }

--- a/src/generated/graphql.d.ts
+++ b/src/generated/graphql.d.ts
@@ -32149,10 +32149,40 @@ export type WorkflowsParametersInput = {
 export type NextIssueLabelsQueryVariables = Exact<{
   repo: Scalars['String']['input'];
   owner: Scalars['String']['input'];
-  issueNumber: Scalars['Int']['input'];
+  number: Scalars['Int']['input'];
   pageSize: Scalars['Int']['input'];
   lastEndCursor?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type NextIssueLabelsQuery = { __typename?: 'Query', repository?: { __typename?: 'Repository', issue?: { __typename?: 'Issue', labels?: { __typename?: 'LabelConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Label', id: string, name: string, resourcePath: any } | null> | null } | null } | null } | null };
+export type NextIssueLabelsQuery = { __typename?: 'Query', repository?: { __typename?: 'Repository', issue?: { __typename?: 'Issue', labels?: { __typename?: 'LabelConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Label', name: string } | null> | null } | null } | null } | null };
+
+export type NextPullRequestLabelsQueryVariables = Exact<{
+  repo: Scalars['String']['input'];
+  owner: Scalars['String']['input'];
+  number: Scalars['Int']['input'];
+  pageSize: Scalars['Int']['input'];
+  lastEndCursor?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type NextPullRequestLabelsQuery = { __typename?: 'Query', repository?: { __typename?: 'Repository', pullRequest?: { __typename?: 'PullRequest', labels?: { __typename?: 'LabelConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Label', name: string } | null> | null } | null } | null } | null };
+
+export type NextRepositoryLabelsQueryVariables = Exact<{
+  repo: Scalars['String']['input'];
+  owner: Scalars['String']['input'];
+  pageSize: Scalars['Int']['input'];
+  lastEndCursor?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type NextRepositoryLabelsQuery = { __typename?: 'Query', repository?: { __typename?: 'Repository', labels?: { __typename?: 'LabelConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Label', id: string, name: string } | null> | null } | null } | null };
+
+export type UpdateLabelsMutationVariables = Exact<{
+  labelableId: Scalars['ID']['input'];
+  labelsToAdd: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+  labelsToRemove: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+}>;
+
+
+export type UpdateLabelsMutation = { __typename?: 'Mutation', addLabelsToLabelable?: { __typename: 'AddLabelsToLabelablePayload' } | null, removeLabelsFromLabelable?: { __typename: 'RemoveLabelsFromLabelablePayload' } | null };

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,28 +1,26 @@
 import type { Octokit } from '@octokit/action'
 import type { RequestParameters } from '@octokit/types'
-import type { NextIssueLabelsQuery, NextIssueLabelsQueryVariables } from './generated/graphql.js'
+import type { NextIssueLabelsQuery, NextIssueLabelsQueryVariables, NextPullRequestLabelsQuery, NextPullRequestLabelsQueryVariables, NextRepositoryLabelsQuery, NextRepositoryLabelsQueryVariables, UpdateLabelsMutation, UpdateLabelsMutationVariables } from './generated/graphql.js'
 
-type Query = {
-  __typename?: 'Query'
+type Request = {
+  __typename?: 'Query' | 'Mutation'
 }
 
-function query<TQuery extends Query> (gh: Octokit, query: string, variables: RequestParameters): Promise<TQuery> {
-  return gh.graphql<TQuery>(query, variables)
+function req<T extends Request> (gh: Octokit, query: string, variables: RequestParameters): Promise<T> {
+  return gh.graphql<T>(query, variables)
 }
 
 const nextIssueLabelsQuery = /* GraphQL */ `
-  query nextIssueLabels($repo: String!, $owner: String!, $issueNumber: Int!, $pageSize: Int!, $lastEndCursor: String) {
+  query nextIssueLabels($repo: String!, $owner: String!, $number: Int!, $pageSize: Int!, $lastEndCursor: String) {
     repository(name: $repo, owner: $owner) {
-      issue(number: $issueNumber) {
+      issue(number: $number) {
         labels(first: $pageSize, after: $lastEndCursor) {
           pageInfo {
             endCursor
             hasNextPage
           }
           nodes {
-            id
             name
-            resourcePath
           }
         }
       }
@@ -30,32 +28,152 @@ const nextIssueLabelsQuery = /* GraphQL */ `
   }
 `
 
-export async function queryNextIssueLabels (gh: Octokit, variables: NextIssueLabelsQueryVariables): Promise<NextIssueLabelsQuery> {
-  return await query<NextIssueLabelsQuery>(gh, nextIssueLabelsQuery, variables)
+function queryNextIssueLabels (gh: Octokit, variables: NextIssueLabelsQueryVariables): Promise<NextIssueLabelsQuery> {
+  return req(gh, nextIssueLabelsQuery, variables)
 }
 
-export async function enumerateIssueLabels (gh: Octokit, { repo, owner, issueNumber }: { repo: string, owner: string, issueNumber: number }): Promise<string[]> {
+const nextPullRequestLabelsQuery = /* GraphQL */ `
+  query nextPullRequestLabels($repo: String!, $owner: String!, $number: Int!, $pageSize: Int!, $lastEndCursor: String) {
+    repository(name: $repo, owner: $owner) {
+      pullRequest(number: $number) {
+        labels(first: $pageSize, after: $lastEndCursor) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+          nodes {
+            name
+          }
+        }
+      }
+    }
+  }
+`
+
+function queryNextPullRequestLabels (gh: Octokit, variables: NextPullRequestLabelsQueryVariables): Promise<NextPullRequestLabelsQuery> {
+  return req(gh, nextPullRequestLabelsQuery, variables)
+}
+
+type GetLabelsRequest = {
+  repo: string,
+  owner: string,
+} & ({ issue: { number: number }} | { pullRequest: { number: number }})
+
+export async function getLabelsOnIssueLike (gh: Octokit, { repo, owner, ...issueLike }: GetLabelsRequest): Promise<string[]> {
   const labels: string[] = []
   let lastEndCursor: string | undefined
   let done = false
 
   while (!done) {
-    const res = await queryNextIssueLabels(gh, {
-      repo, owner, issueNumber, pageSize: 100, lastEndCursor
-    })
-    if (!res.repository?.issue?.labels?.nodes) {
-      throw Error('failed to query issue labels')
+    if ('issue' in issueLike) {
+      const res = await queryNextIssueLabels(gh, {
+        repo, owner, number: issueLike.issue.number, pageSize: 100, lastEndCursor
+      })
+      if (!res.repository?.issue?.labels?.nodes) {
+        throw Error(`failed to get labels on issue #${issueLike.issue.number}`)
+      }
+      const { endCursor, hasNextPage } = res.repository.issue.labels.pageInfo
+      for (const node of res.repository.issue.labels.nodes) {
+        if (node?.name) {
+          labels.push(node.name)
+        }
+      }
+      lastEndCursor = endCursor ?? undefined
+      done = !hasNextPage
+    } else if ('pullRequest' in issueLike) {
+      const res = await queryNextPullRequestLabels(gh, {
+        repo, owner, number: issueLike.pullRequest.number, pageSize: 100, lastEndCursor
+      })
+      if (!res.repository?.pullRequest?.labels?.nodes) {
+        throw Error(`failed to get labels on pull request #${issueLike.pullRequest.number}`)
+      }
+      const { endCursor, hasNextPage } = res.repository.pullRequest.labels.pageInfo
+      for (const node of res.repository.pullRequest.labels.nodes) {
+        if (node?.name) {
+          labels.push(node.name)
+        }
+      }
+      lastEndCursor = endCursor ?? undefined
+      done = !hasNextPage
+    } else {
+      throw new Error('unreachable')
     }
-    const { endCursor, hasNextPage } = res.repository.issue.labels.pageInfo
-    for (const node of res.repository.issue.labels.nodes) {
-      if (node?.name) {
-        labels.push(node.name)
+  }
+
+  return labels
+}
+
+const nextRepositoryLabelsQuery = /* GraphQL */ `
+   query nextRepositoryLabels($repo: String!, $owner: String!, $pageSize: Int!, $lastEndCursor: String) {
+    repository(name: $repo, owner: $owner) {
+      labels(first: $pageSize, after: $lastEndCursor) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          id
+          name
+        }
       }
     }
+  }
+`
 
+function queryNextRepositoryLabels (gh: Octokit, variables: NextRepositoryLabelsQueryVariables): Promise<NextRepositoryLabelsQuery> {
+  return req(gh, nextRepositoryLabelsQuery, variables)
+}
+
+interface RepoLabelIdsByName {
+  [name: string]: string
+}
+
+export async function getRepositoryLabels (gh: Octokit, { repo, owner }: { repo: string, owner: string }): Promise<RepoLabelIdsByName> {
+  const labels: RepoLabelIdsByName = {}
+  let lastEndCursor: string | undefined
+  let done = false
+
+  while (!done) {
+    const res = await queryNextRepositoryLabels(gh, {
+      repo, owner, pageSize: 100, lastEndCursor
+    })
+    if (!res.repository?.labels?.nodes) {
+      throw Error('failed to get labels of repository')
+    }
+    const { endCursor, hasNextPage } = res.repository.labels.pageInfo
+    for (const node of res.repository.labels.nodes) {
+      if (node?.name) {
+        labels[node.name] = node.id
+      }
+    }
     lastEndCursor = endCursor ?? undefined
     done = !hasNextPage
   }
 
   return labels
+}
+
+const updateLabelsMutation = /* GraphQL */ `
+  mutation updateLabels(
+    $labelableId: ID!
+    $labelsToAdd: [ID!]!
+    $labelsToRemove: [ID!]!
+  ) {
+    addLabelsToLabelable(input: {
+      labelableId: $labelableId
+      labelIds: $labelsToAdd
+    }) {
+      __typename
+    }
+    removeLabelsFromLabelable(input: {
+      labelableId: $labelableId
+      labelIds: $labelsToRemove
+    }) { 
+      __typename
+    }
+  }
+`
+
+export function updateLabels (gh: Octokit, variables: UpdateLabelsMutationVariables): Promise<UpdateLabelsMutation> {
+  return req(gh, updateLabelsMutation, variables)
 }


### PR DESCRIPTION
Ahoy! Now we can auto-label pull requests just like issues.
To process pull requests, needs to give workflow permission to `write`
on `pull-requests` or the action fails:

```yaml
on:
  pull_request:
jobs:
  foo:
    permissions:
      pull-requests: write
    steps:
      - uses: oakcask/github-action-auto-label-issue@v2
        with:
          token: "${{ secrets.GITHUB_TOKEN }}"
          configuration-path: examples/config.yaml
```
