### PR TITLE
fix: allow bare pattern

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -34,3 +34,5 @@ label-test:pirate:caribbean:
     - "[Aa]hoy"
     - "[Mm]atey"
     - ([AR]a*|Ya+)rrr+!
+
+label-test: "set: label-test"

--- a/src/action.ts
+++ b/src/action.ts
@@ -71,20 +71,23 @@ function getConfiguration (path: string): Configuration {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const configString = yaml.load(fs.readFileSync(path, 'utf-8')) as any
   return Object.entries(configString).reduce((a, [key, value]) => {
-    if (Array.isArray(value)) {
-      a[key] = {
-        expression: value,
-        removeOnMissing: false
-      }
-    } else {
-      const item = value as { [key: string]: unknown }
-      const { removeOnMissing, ...expression } = item
+    if (typeof value === 'object' && value && 'removeOnMissing' in value) {
+      const { removeOnMissing, ...expression } = value
       a[key] = {
         expression,
         removeOnMissing: typeof removeOnMissing === 'boolean' && removeOnMissing
       }
+    } else if (typeof value === 'string') {
+      a[key] = {
+        expression: value,
+        removeOnMissing: false
+      }
+    } else if (Array.isArray(value)) {
+      a[key] = {
+        expression: value,
+        removeOnMissing: false
+      }
     }
-
     return a
   }, {} as Configuration)
 }


### PR DESCRIPTION
Noticed "bare patterns" are unintentionally ignored, enables it.
Bare means that a string where placed as direct child of label name:

```yaml
foo: |-
  this is bare pattern.
```

---
set: label-test