### PR TITLE
chore: fix example workflow error

### DIFF
--- a/.github/workflows/example--auto-label-issue.yaml
+++ b/.github/workflows/example--auto-label-issue.yaml
@@ -8,6 +8,9 @@ jobs:
   mark:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN  }}
       - uses: oakcask/github-action-auto-label-issue@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ jobs:
 ### Configuring Rules
 
 Use `rulebook` input parameter to pass a list of rules inline.
+
 Or `rulebook-path` input parameter to point a external file contains the rulebook.
+Note that the file must be checked out before the action.
 
 #### Syntax
 


### PR DESCRIPTION
address broken CI after https://github.com/oakcask/github-action-auto-label-issue/pull/583